### PR TITLE
Fix inaccuracies and gaps in documentation

### DIFF
--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -243,18 +243,11 @@ Updates the default options to be used for the reveal effect.
   // App.svelte
   import { reveal, setDefaultOptions } from 'svelte-reveal';
   setDefaultOptions({
-  disable: false,
-  reset: false,
-  duration: 800,
-  delay: 0,
-  x: 0,
-  y: 0,
-  rotate: 0,
-  blur: 0,
-  scale: 1,
-  opacity: 0,
-  ...
-});
+    preset: 'fly',
+    duration: 1200,
+    delay: 100,
+    easing: 'easeOutExpo'
+  });
 </script>
 
 <h1 use:reveal>Hello world</h1>

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -178,7 +178,7 @@ Sets the Intersection Observer `threshold` property.
 
 ## `setObserverConfig`
 
-**signature**: `(observerConfig: IntersectionObserverConfig) => IntersectionObserverConfig`
+**signature**: `(observerConfig: Partial<IntersectionObserverConfig>) => IntersectionObserverConfig`
 
 Sets the Intersection Observer configuration.
 

--- a/docs/src/content/docs/reference/options.mdx
+++ b/docs/src/content/docs/reference/options.mdx
@@ -150,15 +150,17 @@ The easing function to use. You can either pass one of the built-in named functi
 
 **Named easing functions:**
 
-- `linear`
-- `easeInSine`, `easeOutSine`, `easeInOutSine`
-- `easeInQuad`, `easeOutQuad`, `easeInOutQuad`
-- `easeInCubic`, `easeOutCubic`, `easeInOutCubic`
-- `easeInQuart`, `easeOutQuart`, `easeInOutQuart`
-- `easeInQuint`, `easeOutQuint`, `easeInOutQuint`
-- `easeInExpo`, `easeOutExpo`, `easeInOutExpo`
-- `easeInCirc`, `easeOutCirc`, `easeInOutCirc`
-- `easeInBack`, `easeOutBack`, `easeInOutBack`
+| Family | Variants |
+|--------|----------|
+| Linear | `linear` |
+| Sine | `easeInSine`, `easeOutSine`, `easeInOutSine` |
+| Quad | `easeInQuad`, `easeOutQuad`, `easeInOutQuad` |
+| Cubic | `easeInCubic`, `easeOutCubic`, `easeInOutCubic` |
+| Quart | `easeInQuart`, `easeOutQuart`, `easeInOutQuart` |
+| Quint | `easeInQuint`, `easeOutQuint`, `easeInOutQuint` |
+| Expo | `easeInExpo`, `easeOutExpo`, `easeInOutExpo` |
+| Circ | `easeInCirc`, `easeOutCirc`, `easeInOutCirc` |
+| Back | `easeInBack`, `easeOutBack`, `easeInOutBack` |
 
 ```svelte
 <script lang="ts">

--- a/docs/src/content/docs/reference/options.mdx
+++ b/docs/src/content/docs/reference/options.mdx
@@ -150,17 +150,15 @@ The easing function to use. You can either pass one of the built-in named functi
 
 **Named easing functions:**
 
-| Name | Name | Name |
-|------|------|------|
-| `linear` | `easeInSine` | `easeOutSine` |
-| `easeInOutSine` | `easeInQuad` | `easeOutQuad` |
-| `easeInOutQuad` | `easeInCubic` | `easeOutCubic` |
-| `easeInOutCubic` | `easeInQuart` | `easeOutQuart` |
-| `easeInOutQuart` | `easeInQuint` | `easeOutQuint` |
-| `easeInOutQuint` | `easeInExpo` | `easeOutExpo` |
-| `easeInOutExpo` | `easeInCirc` | `easeOutCirc` |
-| `easeInOutCirc` | `easeInBack` | `easeOutBack` |
-| `easeInOutBack` | | |
+- `linear`
+- `easeInSine`, `easeOutSine`, `easeInOutSine`
+- `easeInQuad`, `easeOutQuad`, `easeInOutQuad`
+- `easeInCubic`, `easeOutCubic`, `easeInOutCubic`
+- `easeInQuart`, `easeOutQuart`, `easeInOutQuart`
+- `easeInQuint`, `easeOutQuint`, `easeInOutQuint`
+- `easeInExpo`, `easeOutExpo`, `easeInOutExpo`
+- `easeInCirc`, `easeOutCirc`, `easeInOutCirc`
+- `easeInBack`, `easeOutBack`, `easeInOutBack`
 
 ```svelte
 <script lang="ts">

--- a/docs/src/content/docs/reference/options.mdx
+++ b/docs/src/content/docs/reference/options.mdx
@@ -28,7 +28,7 @@ When set to `true`, the transition is disabled for the target element.
   import { reveal } from 'svelte-reveal';
 </script>
 
-<h1 use:reveal={{ disable: false }}>Hello world</h1>
+<h1 use:reveal={{ disable: true }}>Hello world</h1>
 ```
 
 ### `root`

--- a/docs/src/content/docs/reference/options.mdx
+++ b/docs/src/content/docs/reference/options.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-Depending on the use case, you can either use this library as-is (which applies some [default options](./src/internal/default/options.ts)), or customize it to your liking. If you choose to do so, you can pass an object to this action containing your own options to be applied.
+Depending on the use case, you can either use this library as-is (which applies some [default options](https://github.com/DaveKeehl/svelte-reveal/blob/main/packages/svelte-reveal/src/internal/default/options.ts)), or customize it to your liking. If you choose to do so, you can pass an object to this action containing your own options to be applied.
 
 Keep in mind that these options are applied to the single DOM element you add Svelte Reveal to. For global and more in-depth settings, refer to the [API](/reference/api) section.
 
@@ -21,7 +21,7 @@ Fields are simple flags and values you can set on a specific element to change i
 **type**: `boolean` <br/>
 **default**: `false`
 
-When set to false, the transition is disabled for the target element.
+When set to `true`, the transition is disabled for the target element.
 
 ```svelte
 <script lang="ts">
@@ -143,17 +143,35 @@ How long the transition is delayed (in ms) before being triggered.
 
 ### `easing`
 
-**type**: [`Easing`](https://github.com/DaveKeehl/svelte-reveal/blob/main/packages/svelte-reveal/src/internal/types/easing.ts)<br/>
+**type**: `string | [number, number, number, number]`<br/>
 **default**: `"easeInOutCubic"`
 
-The easing function to use. Check out the full list of available [easing functions](https://github.com/DaveKeehl/svelte-reveal/blob/main/packages/svelte-reveal/src/internal/default/easing.ts) and [this other website](https://cubic-bezier.com/) to preview timing functions.
+The easing function to use. You can either pass one of the built-in named functions listed below, or a custom cubic bezier curve as an array of four numbers `[x1, y1, x2, y2]`. Use [cubic-bezier.com](https://cubic-bezier.com/) to preview timing functions visually.
+
+**Named easing functions:**
+
+| Name | Name | Name |
+|------|------|------|
+| `linear` | `easeInSine` | `easeOutSine` |
+| `easeInOutSine` | `easeInQuad` | `easeOutQuad` |
+| `easeInOutQuad` | `easeInCubic` | `easeOutCubic` |
+| `easeInOutCubic` | `easeInQuart` | `easeOutQuart` |
+| `easeInOutQuart` | `easeInQuint` | `easeOutQuint` |
+| `easeInOutQuint` | `easeInExpo` | `easeOutExpo` |
+| `easeInOutExpo` | `easeInCirc` | `easeOutCirc` |
+| `easeInOutCirc` | `easeInBack` | `easeOutBack` |
+| `easeInOutBack` | | |
 
 ```svelte
 <script lang="ts">
   import { reveal } from 'svelte-reveal';
 </script>
 
+<!-- named function -->
 <h1 use:reveal={{ easing: 'easeInOutCubic' }}>Hello world</h1>
+
+<!-- custom cubic bezier -->
+<h1 use:reveal={{ easing: [0.65, 0, 0.35, 1] }}>Hello world</h1>
 ```
 
 ### `x`
@@ -546,7 +564,7 @@ The element fades in and gets to the original rotation degree.
 
 ```css
 opacity: 0;
-transform: rotate(-10);
+transform: rotate(-10deg);
 ```
 
 </TabItem>
@@ -554,7 +572,7 @@ transform: rotate(-10);
   
 ```css
 opacity: 1;  
-transform: rotate(0);
+transform: rotate(0deg);
 ```
 
 </TabItem>

--- a/docs/src/content/docs/start-here/getting-started.mdx
+++ b/docs/src/content/docs/start-here/getting-started.mdx
@@ -63,42 +63,60 @@ bun add -D svelte-reveal
     </script>
     ```
 
-2.  Add the custom preprocessor to your `svelte.config.js`
-
-    ```js
-    // svelte.config.js
-    import { svelteRevealPreprocess } from 'svelte-reveal';
-
-    const config = {
-      ...
-      preprocess: [..., svelteRevealPreprocess()],
-      ...
-    };
-    ```
-
-3.  Add the imported `reveal` action to the DOM element you want to transition:
+2.  Add the imported `reveal` action to the DOM element you want to transition:
 
     ```svelte
-    // App.svelte
+    <!-- App.svelte -->
     <h1 use:reveal>Hello world</h1>
-    <p use:reveal={{ transition: 'slide' }}>A paragraph</p>
+    <p use:reveal={{ preset: 'slide' }}>A paragraph</p>
     ```
 
     If you want to use the action on a Svelte component, you need to pass the reveal options via props:
 
+    <Tabs>
+
+    <TabItem label="Svelte 5">
+
     ```svelte
-    <script>
-      // App.svelte
+    <!-- App.svelte -->
+    <script lang="ts">
       import Heading from './Heading.svelte';
     </script>
 
-    <Heading useReveal={{ transition: 'slide' }}>Hello world</Heading>
+    <Heading useReveal={{ preset: 'slide' }}>Hello world</Heading>
     ```
 
     ```svelte
+    <!-- Heading.svelte -->
     <script lang="ts">
-      // Heading.svelte
       import { reveal, type RevealOptions } from 'svelte-reveal';
+
+      let { useReveal, children }: { useReveal: RevealOptions; children: any } = $props();
+    </script>
+
+    <h1 use:reveal={useReveal}>
+      {@render children()}
+    </h1>
+    ```
+
+    </TabItem>
+
+    <TabItem label="Svelte 4">
+
+    ```svelte
+    <!-- App.svelte -->
+    <script>
+      import Heading from './Heading.svelte';
+    </script>
+
+    <Heading useReveal={{ preset: 'slide' }}>Hello world</Heading>
+    ```
+
+    ```svelte
+    <!-- Heading.svelte -->
+    <script lang="ts">
+      import { reveal, type RevealOptions } from 'svelte-reveal';
+
       export let useReveal: RevealOptions;
     </script>
 
@@ -106,6 +124,10 @@ bun add -D svelte-reveal
       <slot />
     </h1>
     ```
+
+    </TabItem>
+
+    </Tabs>
 
 </Steps>
 

--- a/docs/src/content/docs/start-here/getting-started.mdx
+++ b/docs/src/content/docs/start-here/getting-started.mdx
@@ -57,8 +57,8 @@ bun add -D svelte-reveal
 1.  Import the library in your Svelte component:
 
     ```svelte
+    <!-- App.svelte -->
     <script>
-      // App.svelte
       import { reveal } from 'svelte-reveal';
     </script>
     ```
@@ -89,9 +89,10 @@ bun add -D svelte-reveal
     ```svelte
     <!-- Heading.svelte -->
     <script lang="ts">
+      import type { Snippet } from 'svelte';
       import { reveal, type RevealOptions } from 'svelte-reveal';
 
-      let { useReveal, children }: { useReveal: RevealOptions; children: any } = $props();
+      let { useReveal, children }: { useReveal: RevealOptions; children: Snippet } = $props();
     </script>
 
     <h1 use:reveal={useReveal}>

--- a/docs/src/content/docs/start-here/sveltekit.mdx
+++ b/docs/src/content/docs/start-here/sveltekit.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution" title="Last update: August 2024">
+<Aside type="caution" title="Last update: April 2026">
   This is an active area of research. Please [submit a bug
   report](https://github.com/DaveKeehl/svelte-reveal/issues/new) in case of issues.
 </Aside>
@@ -36,3 +36,7 @@ If your page does need to leverage server-side rendering, guard the reveal actio
   <h1 use:reveal>Hello world</h1>
 {/if}
 ```
+
+<Aside type="caution">
+  Elements wrapped in `{#if browser}` are absent from the server-rendered HTML. If the element contains content that needs to be indexed by search engines or must be visible before JavaScript loads, disable SSR for the page instead.
+</Aside>

--- a/docs/src/content/docs/start-here/sveltekit.mdx
+++ b/docs/src/content/docs/start-here/sveltekit.mdx
@@ -24,15 +24,15 @@ export const ssr = false;
 
 ## With SSR
 
-If your page does need to leverage server-side rendering, you need to instruct the Svelte Reveal preprocessor to go in ssr mode as follows. Doing as such will prevent the elements to flicker as soon as the page is hydrated and the DOM is accessible to the library.
+If your page does need to leverage server-side rendering, guard the reveal action behind a browser environment check. This prevents elements from flickering when the page is hydrated and the DOM becomes accessible to the library.
 
-```js
-// svelte.config.js
-import { svelteRevealPreprocess } from 'svelte-reveal';
+```svelte
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { reveal } from 'svelte-reveal';
+</script>
 
-const config = {
-  ...
-  preprocess: [..., svelteRevealPreprocess({ ssr: true})],
-  ...
-};
+{#if browser}
+  <h1 use:reveal>Hello world</h1>
+{/if}
 ```


### PR DESCRIPTION
Fix several documentation bugs and gaps found across the reference and getting started guides:

- Remove references to `svelteRevealPreprocess` — it was never implemented
- Replace SvelteKit SSR workaround with a `$app/environment` browser check
- Fix `disable` option description (inverted: false → true)
- Fix broken relative path link in options.mdx intro
- Fix `spin` preset CSS missing `deg` units
- Expand `easing` docs with full function table and custom bezier syntax
- Fix `setDefaultOptions` example (had invalid `...` spread)
- Add Svelte 5 runes syntax alongside Svelte 4 in component usage example
- Fix `transition: 'slide'` → `preset: 'slide'` (option removed in v1.0.0)